### PR TITLE
Fixed instruction to run the examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Rebuild the app, and you’ll have a clean, borderless window.
 
 2. Build the release version of your application:
    ```bash
+   cd example/
    flutter build linux --release
    ```
 
@@ -158,10 +159,9 @@ Rebuild the app, and you’ll have a clean, borderless window.
 
 ### Running the Application
 
-You can run the bundled application directly:
+You can run the omarchy demo application directly from the example folder:
 ```bash
-cd build/linux/x64/release/bundle/
-./your_app_name
+./build/linux/x64/release/bundle/flutter_omarchy_demo
 ```
 
 ## Running on other platforms *(Windows, macOS, Android, iOS, Web)*
@@ -179,8 +179,8 @@ Note that these examples are just basic showcases for components, and the logic 
 To run one of the example application from Omarchy:
 
 ```bash
-cd example
-flutter run --app=pomodoro
+cd ./build/linux/x64/release/bundle/
+./flutter_omarchy_demo --app=counter
 ```
 
 ### Counter


### PR DESCRIPTION
Hi,
I was not able to run the examples using the original README.

First of all I had to run the build command `flutter build linux --release` inside `example/`, second to run the examples I had to do the same of what the `launch_all_apps.sh` states so `./flutter_omarchy_demo --app=pomodoro` inside the build folder and then I was able to run all the examples. 

I've fixed the instruction if in any case I was right.

```
Flutter 3.35.2 • channel stable • https://github.com/flutter/flutter.git
Framework • revision 05db968908 (5 days ago) • 2025-08-25 10:21:35 -0700
Engine • hash abb725c9a5211af2a862b83f74b7eaf2652db083 (revision a8bfdfc394) (7 days ago) • 2025-08-22 23:51:12.000Z
Tools • Dart 3.9.0 • DevTools 2.48.0
```

<img width="1268" height="171" alt="image" src="https://github.com/user-attachments/assets/0e1dfc89-1df5-4141-97f6-dd380449afaf" />
